### PR TITLE
fix: pre-commit hook installation fails

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,5 +40,4 @@ jobs:
       - name: Test Dependencies
         run: |
           ast-grep --help
-          pre-commit install
-          pre-commit install-hooks
+          pre-commit install --install-hooks


### PR DESCRIPTION
When copilot commited pre-commit would start installing the hooks which then reached a timeout for the tool command. So it wasn't possible for pre-commit to run.

This installs the envs for the hooks explicitly and caches them.